### PR TITLE
fix(logger): adjust levels, log with message

### DIFF
--- a/src/genre/controller/post-genre.mjs
+++ b/src/genre/controller/post-genre.mjs
@@ -10,7 +10,7 @@ export function makePostGenre({ addGenre, logger }) {
         body: genre,
       };
     } catch (e) {
-      logger.warn(e);
+      logger.warn(e.message, e);
       return {
         headers,
         statusCode: 400,

--- a/src/logger/logger.mjs
+++ b/src/logger/logger.mjs
@@ -14,7 +14,7 @@ const logConfig = {
     maxSize: "20m",
   },
   exceptions: {
-    level: "warn",
+    level: "error",
     filename: "logs/Rental-Exceptions-%DATE%.log",
     datePattern: "YYYY-MMM-DD-HH",
     maxFiles: "14d",


### PR DESCRIPTION
> changed the level for exception transport to prevent duplicate logs, file logger already had warn
> post-genre logger no longer is missing a log message
