### PR TITLE
fix(post-genre.test): Use correct log params

### DIFF
--- a/src/genre/controller/post-genre.test.mjs
+++ b/src/genre/controller/post-genre.test.mjs
@@ -39,7 +39,7 @@ describe("post genre", () => {
 
       const actual = await postGenre({ body: genre });
 
-      expect(logger.warn).toHaveBeenCalledWith(error);
+      expect(logger.warn).toHaveBeenCalledWith(error.message, error);
       expect(logger.warn).toHaveBeenCalledTimes(1);
 
       expect(actual).toMatchObject({


### PR DESCRIPTION
fixed failing test, required 2 params
